### PR TITLE
Update `@subsquid/substrate-metadata-explorer` to `3.2.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
-        "@subsquid/substrate-metadata-explorer": "^3.1.2",
+        "@subsquid/substrate-metadata-explorer": "^3.2.0",
         "@subsquid/substrate-typegen": "^8.1.0",
         "@subsquid/typeorm-codegen": "^2.0.0",
         "@types/node": "^20.12.7",
@@ -516,13 +516,14 @@
       }
     },
     "node_modules/@subsquid/rpc-client": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.8.0.tgz",
-      "integrity": "sha512-cFtxw1O/8iWYcp/bJmErPTDnMOm1YHuK1MnDoMDlG+q+yCFW8YzvFayNwOjnzyIaJuwoluMeMw1euW3EOaRLAg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.9.0.tgz",
+      "integrity": "sha512-lpb6qRMMlaacXOFPRhv4CZ7g4w7pKIR7ZEbMjyFexLOdv9MkcYzuGD5XT5REGaBA6mfQMaLa33K5lqAb+tJKBQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@subsquid/http-client": "^1.4.0",
         "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.1.0",
+        "@subsquid/util-internal": "^3.2.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0",
         "@subsquid/util-internal-counters": "^1.3.2",
         "@subsquid/util-internal-json-fix-unsafe-integers": "^0.0.0",
@@ -604,16 +605,18 @@
       }
     },
     "node_modules/@subsquid/substrate-metadata-explorer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/substrate-metadata-explorer/-/substrate-metadata-explorer-3.1.2.tgz",
-      "integrity": "sha512-wITx+R5REa25uRFKF2fsWC3bOFOde80MEZrgfbjs5aAt4eNKHOL6s61g4xJRNIqXrRG20Drl/gLkBdMYSjnIgQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-metadata-explorer/-/substrate-metadata-explorer-3.2.0.tgz",
+      "integrity": "sha512-sir8ZDjJ8bCErbrx3USy6qBq0Nszyqu5UOO+8jcnZ1OCvKPJDzudu9m1SExjzRShdKoKroSObTMQA52fchC4Vw==",
       "dev": true,
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/logger": "^1.3.2",
-        "@subsquid/rpc-client": "^4.5.0",
-        "@subsquid/util-internal": "^3.0.0",
-        "@subsquid/util-internal-commander": "^1.3.2",
+        "@subsquid/logger": "^1.3.3",
+        "@subsquid/rpc-client": "^4.9.0",
+        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/util-internal-commander": "^1.4.0",
         "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-range": "^0.3.0",
         "@subsquid/util-internal-read-lines": "^1.2.2",
         "commander": "^11.1.0"
       },
@@ -753,9 +756,10 @@
       }
     },
     "node_modules/@subsquid/util-internal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.1.0.tgz",
-      "integrity": "sha512-m1lIiy7Tc2+QR5Jcx9eGsVsB4ASR/bA5Z9gnB+qUy1BzYuz5FEiJOYCQm6J5Bt+VnYDYYyANEUMq4Cl3J5wuSg=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.2.0.tgz",
+      "integrity": "sha512-foNCjOmZaP8MKMa9sNe2GXTjFSDM9UqA0I0C0/ZvCxM1lCmG3mxZb70f8Wyi7TePXC/eV8eARbIqFyz0GjQmzA==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-archive-client": {
       "version": "0.1.2",
@@ -786,9 +790,10 @@
       "integrity": "sha512-uerf8T/FU4bxxhat09MgRrdmwifLwV+tO7QvlMvZ5ccwaVrJjHs+0/LY/h1e9YowH3+ZtwPqjYrd5tNOHWX8wA=="
     },
     "node_modules/@subsquid/util-internal-commander": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-commander/-/util-internal-commander-1.3.2.tgz",
-      "integrity": "sha512-9/1vI1dmGQMp5wjN6hb94VCnSosT+caob33tAesFaIdqLzqQlDtlTSRq1TFFossAgtsEJFi7GiQ8i31L/gaxSQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-commander/-/util-internal-commander-1.4.0.tgz",
+      "integrity": "sha512-I+IztlLVow9z2S5lK/ON4aBRYXKtAKXl/rVPUn1Ue5vq+5JgEFbWEKJgnwXkd0qKnKeoYeaRFlcyQVfxirxzJw==",
+      "license": "GPL-3.0-or-later",
       "peerDependencies": {
         "commander": "^11.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typeorm": "^0.3.20"
   },
   "devDependencies": {
-    "@subsquid/substrate-metadata-explorer": "^3.1.2",
+    "@subsquid/substrate-metadata-explorer": "^3.2.0",
     "@subsquid/substrate-typegen": "^8.1.0",
     "@subsquid/typeorm-codegen": "^2.0.0",
     "@types/node": "^20.12.7",


### PR DESCRIPTION
New version accepts `--fromBlock` CLI parameter.