### PR TITLE
Temporary fix for the bucket storage version selection

### DIFF
--- a/src/processors/ddcBucketsProcessor.ts
+++ b/src/processors/ddcBucketsProcessor.ts
@@ -31,8 +31,17 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
         bucketId: bigint,
         block: BlockHeader,
     ) {
+        // TODO(khssnv)
+        // The `blockSpecVersion` is added because previously the following
+        // `storage.ddcCustomers.buckets.v48013.is(block)` returned `true` when `v54100` is
+        // expected. Remove it and return back to the `.is(block)` version selector when
+        // the problem is fixed. With `blockSpecVersion` we can't detect if incoming block has an
+        // unsupported future version of the storage.
+        const blockSpecVersion = block._runtime.specVersion
+
         let bucketInfo: DdcBucketInfo | undefined
-        if (storage.ddcCustomers.buckets.v48013.is(block)) {
+        // if (storage.ddcCustomers.buckets.v48013.is(block)) {
+        if (blockSpecVersion >= 48013 && blockSpecVersion < 48017) {
             const bucket = await storage.ddcCustomers.buckets.v48013.get(
                 block,
                 bucketId,
@@ -50,7 +59,8 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                     numberOfGets: 0n,
                 }
             }
-        } else if (storage.ddcCustomers.buckets.v48017.is(block)) {
+        // } else if (storage.ddcCustomers.buckets.v48017.is(block)) {
+        } else if (blockSpecVersion <= 48017 && blockSpecVersion < 50000) {
             const bucket = await storage.ddcCustomers.buckets.v48017.get(
                 block,
                 bucketId,
@@ -68,7 +78,8 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                     numberOfGets: 0n,
                 }
             }
-        } else if (storage.ddcCustomers.buckets.v50000.is(block)) {
+        // } else if (storage.ddcCustomers.buckets.v50000.is(block)) {
+        } else if (blockSpecVersion >= 50000 && blockSpecVersion < 54100) {
             const bucket = await storage.ddcCustomers.buckets.v50000.get(
                 block,
                 bucketId,
@@ -86,7 +97,8 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                     numberOfGets: 0n,
                 }
             }
-        } else if (storage.ddcCustomers.buckets.v54100.is(block)) {
+        // } else if (storage.ddcCustomers.buckets.v54100.is(block)) {
+        } else if (blockSpecVersion >= 54100) {
             const bucket = await storage.ddcCustomers.buckets.v54100.get(
                 block,
                 bucketId,


### PR DESCRIPTION
The following check unexpectedly returns true for a block with a bucket storage layout `v54100`.

https://github.com/Cerebellum-Network/cere-squid-indexer/blob/635b47fa1513dfe843325d6dfe18f59b1da42c22/src/processors/ddcBucketsProcessor.ts#L35

The patch replaces `.is(block)` calls with spec versions comparisons. This fixes the problem with the wrong bucket storage layout selection. At the same time we are losing an ability to detect if an incoming block has an unsupported (future) version of the storage and this patch should be reverted as soon as the `.is(block)` check fixed.

I've also checked if other processors affected and have not found the same problem with `storage.system.account.v266.is(block)` in `CereBalancesProcessor`.