### PR TITLE
Decode values from SCALE hex-strings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+    "printWidth": 120,
     "semi": false,
     "singleQuote": true,
     "tabWidth": 4

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "squid",
       "dependencies": {
+        "@polkadot/types": "^12.3.1",
         "@subsquid/graphql-server": "^4.5.1",
         "@subsquid/ss58": "^2.0.2",
         "@subsquid/substrate-processor": "^8.3.0",
@@ -332,6 +333,30 @@
         "node": ">= 12"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.5.0.tgz",
+      "integrity": "sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -339,6 +364,314 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.0.2.tgz",
+      "integrity": "sha512-NeLbhyKDT5W8LI9seWTZGePxNTOVpDhv2018HSrEDwJq9Ie0C4TZhUf3KNERCkSveuThXjfQJMs+1CF33ZXPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "13.0.2",
+        "@polkadot/util-crypto": "13.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.0.2",
+        "@polkadot/util-crypto": "13.0.2"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.0.2.tgz",
+      "integrity": "sha512-ABAL+vug/gIwkdFEzeh87JoJd0YKrxSYg/HjUrZ+Zis2ucxQEKpvtCpJ34ku+YrjacBfVqIAkkwd3ZdIPGq9aQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "13.0.2",
+        "@substrate/ss58-registry": "^1.46.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-12.3.1.tgz",
+      "integrity": "sha512-4MkTF1znpgp9mZc/ZZPdFe7/5it9v+EJmzXc/DEOX9kVWs2BuKOWopzOFyO3reVUUB+v7dxfSOArSsxkMUcuoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^13.0.2",
+        "@polkadot/types-augment": "12.3.1",
+        "@polkadot/types-codec": "12.3.1",
+        "@polkadot/types-create": "12.3.1",
+        "@polkadot/util": "^13.0.2",
+        "@polkadot/util-crypto": "^13.0.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-12.3.1.tgz",
+      "integrity": "sha512-I3ggJt7W3UOScP6WA6PNmNsmpCfZtXkRJvSJkX7bi2LsSm/iF0xo0KdpQK02dHu7nGRFD9O5cSoVawzZJifGLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "12.3.1",
+        "@polkadot/types-codec": "12.3.1",
+        "@polkadot/util": "^13.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-12.3.1.tgz",
+      "integrity": "sha512-yZ4exsQI+eVkE/fZNuJBOajAgOH/YncKWOOf0N4lc6iq28oYp22DCAXc50Ym372l4HO+uhC9QdMPH9EiWwT2pQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^13.0.2",
+        "@polkadot/x-bigint": "^13.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-12.3.1.tgz",
+      "integrity": "sha512-Jf9BByWB64FPW3lM5/Mcc/foyPJ3L9t0QwHVHaYWaonZt6l7SPX71rQmD7twJiTj9q1d1WidDKg/TtRDNbm1yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "12.3.1",
+        "@polkadot/util": "^13.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.0.2.tgz",
+      "integrity": "sha512-/6bS9sfhJLhs8QuqWaR1eRapzfDdGC5XAQZEPL9NN5sTTA7HxWos8rVleai0UERm8QUMabjZ9rK9KpzbXl7ojg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "13.0.2",
+        "@polkadot/x-global": "13.0.2",
+        "@polkadot/x-textdecoder": "13.0.2",
+        "@polkadot/x-textencoder": "13.0.2",
+        "@types/bn.js": "^5.1.5",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.0.2.tgz",
+      "integrity": "sha512-woUsJJ6zd/caL7U+D30a5oM/+WK9iNI00Y8aNUHSj6Zq/KPzK9uqDBaLGWwlgrejoMQkxxiU2X0f2LzP15AtQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "13.0.2",
+        "@polkadot/util": "13.0.2",
+        "@polkadot/wasm-crypto": "^7.3.2",
+        "@polkadot/wasm-util": "^7.3.2",
+        "@polkadot/x-bigint": "13.0.2",
+        "@polkadot/x-randomvalues": "13.0.2",
+        "@scure/base": "^1.1.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.0.2"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.3.2.tgz",
+      "integrity": "sha512-AJEXChcf/nKXd5Q/YLEV5dXQMle3UNT7jcXYmIffZAo/KI394a+/24PaISyQjoNC0fkzS1Q8T5pnGGHmXiVz2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.3.2.tgz",
+      "integrity": "sha512-+neIDLSJ6jjVXsjyZ5oLSv16oIpwp+PxFqTUaZdZDoA2EyFRQB8pP7+qLsMNk+WJuhuJ4qXil/7XiOnZYZ+wxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.3.2",
+        "@polkadot/wasm-crypto-asmjs": "7.3.2",
+        "@polkadot/wasm-crypto-init": "7.3.2",
+        "@polkadot/wasm-crypto-wasm": "7.3.2",
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.3.2.tgz",
+      "integrity": "sha512-QP5eiUqUFur/2UoF2KKKYJcesc71fXhQFLT3D4ZjG28Mfk2ZPI0QNRUfpcxVQmIUpV5USHg4geCBNuCYsMm20Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.3.2.tgz",
+      "integrity": "sha512-FPq73zGmvZtnuJaFV44brze3Lkrki3b4PebxCy9Fplw8nTmisKo9Xxtfew08r0njyYh+uiJRAxPCXadkC9sc8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.3.2",
+        "@polkadot/wasm-crypto-asmjs": "7.3.2",
+        "@polkadot/wasm-crypto-wasm": "7.3.2",
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.3.2.tgz",
+      "integrity": "sha512-15wd0EMv9IXs5Abp1ZKpKKAVyZPhATIAHfKsyoWCEFDLSOA0/K0QGOxzrAlsrdUkiKZOq7uzSIgIDgW8okx2Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.3.2.tgz",
+      "integrity": "sha512-bmD+Dxo1lTZyZNxbyPE380wd82QsX+43mgCm40boyKrRppXEyQmWT98v/Poc7chLuskYb6X8IQ6lvvK2bGR4Tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.0.2.tgz",
+      "integrity": "sha512-h2jKT/UaxiEal8LhQeH6+GCjO7GwEqVAD2SNYteCOXff6yNttqAZYJuHZsndbVjVNwqRNf8D5q/zZkD0HUd6xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.0.2.tgz",
+      "integrity": "sha512-OoNIXLB5y8vIKpk4R+XmpDPhipNXWSUvEwUnpQT7NAxNLmzgMq1FhbrwBWWPRNHPrQonp7mqxV/X+v5lv1HW/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.0.2.tgz",
+      "integrity": "sha512-SGj+L0H/7TWZtSmtkWlixO4DFzXDdluI0UscN2h285os2Ns8PnmBbue+iJ8PVSzpY1BOxd66gvkkpboPz+jXFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.0.2",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.0.2.tgz",
+      "integrity": "sha512-mauglOkTJxLGmLwLc3J5Jlq/W+SHP53eiy3F8/8JxxfnXrZKgWoQXGpvXYPjFnMZj0MzDSy/6GjyGWnDCgdQFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.0.2.tgz",
+      "integrity": "sha512-Lq08H2OnVXj97uaOwg7tcmRS7a4VJYkHEeWO4FyEMOk6P6lU6W8OVNjjxG0se9PCEgmyZPUDbJI//1ynzP4cXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -394,6 +727,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
+      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
@@ -555,6 +897,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@subsquid/ss58/-/ss58-2.0.2.tgz",
       "integrity": "sha512-2chHMJ7jXvZzYQiXiA5MYYAVBobPcnQxWt3/jsiiZT6vWorjlVElXoQjZ0G/FKRHCcJ4GD10zDd8sG+7sPp2fw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@subsquid/ss58-codec": "^1.2.3",
         "@subsquid/util-internal-hex": "^1.2.2"
@@ -943,10 +1286,25 @@
       "resolved": "https://registry.npmjs.org/@substrate/calc/-/calc-0.2.8.tgz",
       "integrity": "sha512-1c3mxf35FBeOswduhy0Wil9s4exHahXFo974qa0Ci2AORX8JTxmwhBb10+3Ls9iWoTFwvgOaFr9v1HeRL5tCig=="
     },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.49.0.tgz",
+      "integrity": "sha512-leW6Ix4LD7XgvxT7+aobPWSw+WvPcN2Rxof1rmd0mNC5t2n99k1N7UNEvz7YEFSOUeHWmKIY7F5q8KeIqYoHfA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@types/accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1456,6 +1814,12 @@
         "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -3497,6 +3861,15 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format": "prettier . '!./data' --write"
   },
   "dependencies": {
+    "@polkadot/types": "^12.3.1",
     "@subsquid/graphql-server": "^4.5.1",
     "@subsquid/ss58": "^2.0.2",
     "@subsquid/substrate-processor": "^8.3.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,9 +23,7 @@ processor.run(new TypeormDatabase({ supportHotBlocks: true }), async (ctx) => {
     for (let b of ctx.blocks) {
         const block = b.header
         for (let event of b.events) {
-            logger.debug(
-                `Received event ${event.name} at block ${block.height} (${block.hash})`,
-            )
+            logger.debug(`Received event ${event.name} at block ${block.height} (${block.hash})`)
 
             await Promise.all([
                 cereBalancesProcessor.process(event, block),
@@ -74,9 +72,7 @@ processor.run(new TypeormDatabase({ supportHotBlocks: true }), async (ctx) => {
     const ddcClusterAccounts = [...ddcClusters.values()].map((c) => c.managerId)
     await createAccounts(ddcClusterAccounts)
 
-    const ddcNodesAccounts = [...ddcNodes.updatedNodes.values()].map(
-        (c) => c.providerId,
-    )
+    const ddcNodesAccounts = [...ddcNodes.updatedNodes.values()].map((c) => c.providerId)
     await createAccounts(ddcNodesAccounts)
 
     const ddcBucketsAccounts = [...ddcBuckets.values()].map((c) => c.ownerId)

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -10,17 +10,12 @@ import { events } from './types'
 
 export const processor = new SubstrateBatchProcessor()
     .setRpcEndpoint({
-        url: assertNotNull(
-            process.env.RPC_CERE_HTTP,
-            'No RPC endpoint supplied',
-        ),
+        url: assertNotNull(process.env.RPC_CERE_HTTP, 'No RPC endpoint supplied'),
         rateLimit: parseInt(process.env.SQD_RATE_LIMIT || '500'),
         capacity: parseInt(process.env.SQD_CAPACITY || '10'),
     })
     .setBlockRange({ from: parseInt(process.env.SQD_FIRST_BLOCK || '0') })
-    .setTypesBundle(
-        process.env.TYPES_BUNDLE || '../specs/cere-types-bundle.json',
-    )
+    .setTypesBundle(process.env.TYPES_BUNDLE || '../specs/cere-types-bundle.json')
     .addEvent({
         name: [
             events.balances.endowed.name,

--- a/src/processors/cereBalancesProcessor.ts
+++ b/src/processors/cereBalancesProcessor.ts
@@ -1,11 +1,6 @@
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import { events, storage } from '../types'
-import {
-    logStorageError,
-    throwUnsupportedSpec,
-    throwUnsupportedStorageSpec,
-    toCereAddress,
-} from '../utils'
+import { logStorageError, throwUnsupportedSpec, throwUnsupportedStorageSpec, toCereAddress } from '../utils'
 import { BaseProcessor } from './processor'
 
 type State = Map<string, bigint>
@@ -19,36 +14,21 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
         try {
             let accountInStorage
             if (storage.system.account.v266.is(block)) {
-                accountInStorage = await storage.system.account.v266.get(
-                    block,
-                    accountId,
-                )
+                accountInStorage = await storage.system.account.v266.get(block, accountId)
             } else if (storage.system.account.v295.is(block)) {
-                accountInStorage = await storage.system.account.v295.get(
-                    block,
-                    accountId,
-                )
+                accountInStorage = await storage.system.account.v295.get(block, accountId)
             } else if (storage.system.account.v48900.is(block)) {
-                accountInStorage = await storage.system.account.v48900.get(
-                    block,
-                    accountId,
-                )
+                accountInStorage = await storage.system.account.v48900.get(block, accountId)
             } else {
                 throwUnsupportedStorageSpec(block)
             }
             if (accountInStorage) {
-                this._state.set(
-                    toCereAddress(accountId),
-                    accountInStorage.data.free,
-                )
+                this._state.set(toCereAddress(accountId), accountInStorage.data.free)
             } else {
                 logStorageError('account', accountId, block)
             }
         } catch (error) {
-            if (
-                error?.toString() === 'Error: Unexpected EOF' ||
-                error?.toString() === 'Error: Unprocessed data left'
-            ) {
+            if (error?.toString() === 'Error: Unexpected EOF' || error?.toString() === 'Error: Unprocessed data left') {
                 // some accounts in old blocks can not be parsed, just ignore them
             } else {
                 throw error
@@ -60,12 +40,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
         switch (event.name) {
             case events.balances.endowed.name: {
                 if (events.balances.endowed.v266.is(event)) {
-                    const accountId =
-                        events.balances.endowed.v266.decode(event)[0]
+                    const accountId = events.balances.endowed.v266.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.endowed.v297.is(event)) {
-                    const accountId =
-                        events.balances.endowed.v297.decode(event).account
+                    const accountId = events.balances.endowed.v297.decode(event).account
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -74,12 +52,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.dustLost.name: {
                 if (events.balances.dustLost.v266.is(event)) {
-                    const accountId =
-                        events.balances.dustLost.v266.decode(event)[0]
+                    const accountId = events.balances.dustLost.v266.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.dustLost.v297.is(event)) {
-                    const accountId =
-                        events.balances.dustLost.v297.decode(event).account
+                    const accountId = events.balances.dustLost.v297.decode(event).account
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -88,12 +64,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.transfer.name: {
                 if (events.balances.transfer.v266.is(event)) {
-                    const accountId =
-                        events.balances.transfer.v266.decode(event)[0]
+                    const accountId = events.balances.transfer.v266.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.transfer.v297.is(event)) {
-                    const accountId =
-                        events.balances.transfer.v297.decode(event).from
+                    const accountId = events.balances.transfer.v297.decode(event).from
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -102,16 +76,13 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.balanceSet.name: {
                 if (events.balances.balanceSet.v266.is(event)) {
-                    const accountId =
-                        events.balances.balanceSet.v266.decode(event)[0]
+                    const accountId = events.balances.balanceSet.v266.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.balanceSet.v297.is(event)) {
-                    const accountId =
-                        events.balances.balanceSet.v297.decode(event).who
+                    const accountId = events.balances.balanceSet.v297.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.balanceSet.v48900.is(event)) {
-                    const accountId =
-                        events.balances.balanceSet.v48900.decode(event).who
+                    const accountId = events.balances.balanceSet.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -120,12 +91,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.deposit.name: {
                 if (events.balances.deposit.v266.is(event)) {
-                    const accountId =
-                        events.balances.deposit.v266.decode(event)[0]
+                    const accountId = events.balances.deposit.v266.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.deposit.v297.is(event)) {
-                    const accountId =
-                        events.balances.deposit.v297.decode(event).who
+                    const accountId = events.balances.deposit.v297.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -134,12 +103,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.reserved.name: {
                 if (events.balances.reserved.v266.is(event)) {
-                    const accountId =
-                        events.balances.reserved.v266.decode(event)[0]
+                    const accountId = events.balances.reserved.v266.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.reserved.v297.is(event)) {
-                    const accountId =
-                        events.balances.reserved.v297.decode(event).who
+                    const accountId = events.balances.reserved.v297.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -148,12 +115,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.unreserved.name: {
                 if (events.balances.unreserved.v266.is(event)) {
-                    const accountId =
-                        events.balances.unreserved.v266.decode(event)[0]
+                    const accountId = events.balances.unreserved.v266.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.unreserved.v297.is(event)) {
-                    const accountId =
-                        events.balances.unreserved.v297.decode(event).who
+                    const accountId = events.balances.unreserved.v297.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -162,14 +127,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.reserveRepatriated.name: {
                 if (events.balances.reserveRepatriated.v266.is(event)) {
-                    const accountId =
-                        events.balances.reserveRepatriated.v266.decode(event)[0]
+                    const accountId = events.balances.reserveRepatriated.v266.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.reserveRepatriated.v297.is(event)) {
-                    const accountId =
-                        events.balances.reserveRepatriated.v297.decode(
-                            event,
-                        ).from
+                    const accountId = events.balances.reserveRepatriated.v297.decode(event).from
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -178,12 +139,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.withdraw.name: {
                 if (events.balances.withdraw.v296.is(event)) {
-                    const accountId =
-                        events.balances.withdraw.v296.decode(event)[0]
+                    const accountId = events.balances.withdraw.v296.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.withdraw.v297.is(event)) {
-                    const accountId =
-                        events.balances.withdraw.v297.decode(event).who
+                    const accountId = events.balances.withdraw.v297.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -192,12 +151,10 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.slashed.name: {
                 if (events.balances.slashed.v296.is(event)) {
-                    const accountId =
-                        events.balances.slashed.v296.decode(event)[0]
+                    const accountId = events.balances.slashed.v296.decode(event)[0]
                     await this.processBalancesEvent(accountId, block)
                 } else if (events.balances.slashed.v297.is(event)) {
-                    const accountId =
-                        events.balances.slashed.v297.decode(event).who
+                    const accountId = events.balances.slashed.v297.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -206,8 +163,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.minted.name: {
                 if (events.balances.minted.v48900.is(event)) {
-                    const accountId =
-                        events.balances.minted.v48900.decode(event).who
+                    const accountId = events.balances.minted.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -216,8 +172,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.burned.name: {
                 if (events.balances.burned.v48900.is(event)) {
-                    const accountId =
-                        events.balances.burned.v48900.decode(event).who
+                    const accountId = events.balances.burned.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -226,8 +181,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.suspended.name: {
                 if (events.balances.suspended.v48900.is(event)) {
-                    const accountId =
-                        events.balances.suspended.v48900.decode(event).who
+                    const accountId = events.balances.suspended.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -236,8 +190,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.restored.name: {
                 if (events.balances.restored.v48900.is(event)) {
-                    const accountId =
-                        events.balances.restored.v48900.decode(event).who
+                    const accountId = events.balances.restored.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -246,8 +199,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.upgraded.name: {
                 if (events.balances.upgraded.v48900.is(event)) {
-                    const accountId =
-                        events.balances.upgraded.v48900.decode(event).who
+                    const accountId = events.balances.upgraded.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -256,8 +208,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.locked.name: {
                 if (events.balances.locked.v48900.is(event)) {
-                    const accountId =
-                        events.balances.locked.v48900.decode(event).who
+                    const accountId = events.balances.locked.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -266,8 +217,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.unlocked.name: {
                 if (events.balances.unlocked.v48900.is(event)) {
-                    const accountId =
-                        events.balances.unlocked.v48900.decode(event).who
+                    const accountId = events.balances.unlocked.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -276,8 +226,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.frozen.name: {
                 if (events.balances.frozen.v48900.is(event)) {
-                    const accountId =
-                        events.balances.frozen.v48900.decode(event).who
+                    const accountId = events.balances.frozen.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -286,8 +235,7 @@ export class CereBalancesProcessor extends BaseProcessor<State> {
             }
             case events.balances.thawed.name: {
                 if (events.balances.thawed.v48900.is(event)) {
-                    const accountId =
-                        events.balances.thawed.v48900.decode(event).who
+                    const accountId = events.balances.thawed.v48900.decode(event).who
                     await this.processBalancesEvent(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)

--- a/src/processors/ddcBalancesProcessor.ts
+++ b/src/processors/ddcBalancesProcessor.ts
@@ -1,11 +1,6 @@
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import { events, storage } from '../types'
-import {
-    logStorageError,
-    throwUnsupportedSpec,
-    throwUnsupportedStorageSpec,
-    toCereAddress,
-} from '../utils'
+import { logStorageError, throwUnsupportedSpec, throwUnsupportedStorageSpec, toCereAddress } from '../utils'
 import { BaseProcessor } from './processor'
 
 type State = Map<string, bigint>
@@ -15,16 +10,10 @@ export class DdcBalancesProcessor extends BaseProcessor<State> {
         super(new Map<string, bigint>())
     }
 
-    private async processDdcCustomersBalancesEvents(
-        accountId: string,
-        block: BlockHeader,
-    ) {
+    private async processDdcCustomersBalancesEvents(accountId: string, block: BlockHeader) {
         let accountInStorage
         if (storage.ddcCustomers.ledger.v48013.is(block)) {
-            accountInStorage = await storage.ddcCustomers.ledger.v48013.get(
-                block,
-                accountId,
-            )
+            accountInStorage = await storage.ddcCustomers.ledger.v48013.get(block, accountId)
         } else {
             throwUnsupportedStorageSpec(block)
         }
@@ -39,21 +28,11 @@ export class DdcBalancesProcessor extends BaseProcessor<State> {
         switch (event.name) {
             case events.ddcCustomers.deposited.name: {
                 if (events.ddcCustomers.deposited.v48013.is(event)) {
-                    const accountId =
-                        events.ddcCustomers.deposited.v48013.decode(event)[0]
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
+                    const accountId = events.ddcCustomers.deposited.v48013.decode(event)[0]
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
                 } else if (events.ddcCustomers.deposited.v48800.is(event)) {
-                    const accountId =
-                        events.ddcCustomers.deposited.v48800.decode(
-                            event,
-                        ).ownerId
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
+                    const accountId = events.ddcCustomers.deposited.v48800.decode(event).ownerId
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
                 }
@@ -61,14 +40,8 @@ export class DdcBalancesProcessor extends BaseProcessor<State> {
             }
             case events.ddcCustomers.initiatDepositUnlock.name: {
                 if (events.ddcCustomers.initiatDepositUnlock.v48013.is(event)) {
-                    const accountId =
-                        events.ddcCustomers.initiatDepositUnlock.v48013.decode(
-                            event,
-                        )[0]
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
+                    const accountId = events.ddcCustomers.initiatDepositUnlock.v48013.decode(event)[0]
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
                 }
@@ -76,21 +49,11 @@ export class DdcBalancesProcessor extends BaseProcessor<State> {
             }
             case events.ddcCustomers.withdrawn.name: {
                 if (events.ddcCustomers.withdrawn.v48013.is(event)) {
-                    const accountId =
-                        events.ddcCustomers.withdrawn.v48013.decode(event)[0]
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
+                    const accountId = events.ddcCustomers.withdrawn.v48013.decode(event)[0]
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
                 } else if (events.ddcCustomers.withdrawn.v48800.is(event)) {
-                    const accountId =
-                        events.ddcCustomers.withdrawn.v48800.decode(
-                            event,
-                        ).ownerId
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
+                    const accountId = events.ddcCustomers.withdrawn.v48800.decode(event).ownerId
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
                 }
@@ -100,19 +63,11 @@ export class DdcBalancesProcessor extends BaseProcessor<State> {
                 if (events.ddcCustomers.charged.v48013.is(event)) {
                     // unsupported version, just skip
                 } else if (events.ddcCustomers.charged.v48014.is(event)) {
-                    const accountId =
-                        events.ddcCustomers.charged.v48014.decode(event)[0]
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
+                    const accountId = events.ddcCustomers.charged.v48014.decode(event)[0]
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
                 } else if (events.ddcCustomers.charged.v48800.is(event)) {
-                    const accountId =
-                        events.ddcCustomers.charged.v48800.decode(event).ownerId
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
+                    const accountId = events.ddcCustomers.charged.v48800.decode(event).ownerId
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
                 }
@@ -120,25 +75,11 @@ export class DdcBalancesProcessor extends BaseProcessor<State> {
             }
             case events.ddcCustomers.initialDepositUnlock.name: {
                 if (events.ddcCustomers.initialDepositUnlock.v48014.is(event)) {
-                    const accountId =
-                        events.ddcCustomers.initialDepositUnlock.v48014.decode(
-                            event,
-                        )[0]
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
-                } else if (
-                    events.ddcCustomers.initialDepositUnlock.v48800.is(event)
-                ) {
-                    const accountId =
-                        events.ddcCustomers.initialDepositUnlock.v48800.decode(
-                            event,
-                        ).ownerId
-                    await this.processDdcCustomersBalancesEvents(
-                        accountId,
-                        block,
-                    )
+                    const accountId = events.ddcCustomers.initialDepositUnlock.v48014.decode(event)[0]
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
+                } else if (events.ddcCustomers.initialDepositUnlock.v48800.is(event)) {
+                    const accountId = events.ddcCustomers.initialDepositUnlock.v48800.decode(event).ownerId
+                    await this.processDdcCustomersBalancesEvents(accountId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
                 }

--- a/src/processors/ddcBucketsProcessor.ts
+++ b/src/processors/ddcBucketsProcessor.ts
@@ -1,11 +1,6 @@
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import { events, storage } from '../types'
-import {
-    logStorageError,
-    throwUnsupportedSpec,
-    throwUnsupportedStorageSpec,
-    toCereAddress,
-} from '../utils'
+import { logStorageError, throwUnsupportedSpec, throwUnsupportedStorageSpec, toCereAddress } from '../utils'
 import { BaseProcessor } from './processor'
 
 export interface DdcBucketInfo {
@@ -27,10 +22,7 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
         super(new Map<bigint, DdcBucketInfo>())
     }
 
-    private async processDdcBucketsEvents(
-        bucketId: bigint,
-        block: BlockHeader,
-    ) {
+    private async processDdcBucketsEvents(bucketId: bigint, block: BlockHeader) {
         // TODO(khssnv)
         // The `blockSpecVersion` is added because previously the following
         // `storage.ddcCustomers.buckets.v48013.is(block)` returned `true` when `v54100` is
@@ -42,10 +34,7 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
         let bucketInfo: DdcBucketInfo | undefined
         // if (storage.ddcCustomers.buckets.v48013.is(block)) {
         if (blockSpecVersion >= 48013 && blockSpecVersion < 48017) {
-            const bucket = await storage.ddcCustomers.buckets.v48013.get(
-                block,
-                bucketId,
-            )
+            const bucket = await storage.ddcCustomers.buckets.v48013.get(block, bucketId)
             if (bucket) {
                 bucketInfo = {
                     ownerId: bucket.ownerId,
@@ -59,12 +48,9 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                     numberOfGets: 0n,
                 }
             }
-        // } else if (storage.ddcCustomers.buckets.v48017.is(block)) {
+            // } else if (storage.ddcCustomers.buckets.v48017.is(block)) {
         } else if (blockSpecVersion <= 48017 && blockSpecVersion < 50000) {
-            const bucket = await storage.ddcCustomers.buckets.v48017.get(
-                block,
-                bucketId,
-            )
+            const bucket = await storage.ddcCustomers.buckets.v48017.get(block, bucketId)
             if (bucket) {
                 bucketInfo = {
                     ownerId: bucket.ownerId,
@@ -78,12 +64,9 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                     numberOfGets: 0n,
                 }
             }
-        // } else if (storage.ddcCustomers.buckets.v50000.is(block)) {
+            // } else if (storage.ddcCustomers.buckets.v50000.is(block)) {
         } else if (blockSpecVersion >= 50000 && blockSpecVersion < 54100) {
-            const bucket = await storage.ddcCustomers.buckets.v50000.get(
-                block,
-                bucketId,
-            )
+            const bucket = await storage.ddcCustomers.buckets.v50000.get(block, bucketId)
             if (bucket) {
                 bucketInfo = {
                     ownerId: bucket.ownerId,
@@ -97,12 +80,9 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                     numberOfGets: 0n,
                 }
             }
-        // } else if (storage.ddcCustomers.buckets.v54100.is(block)) {
+            // } else if (storage.ddcCustomers.buckets.v54100.is(block)) {
         } else if (blockSpecVersion >= 54100) {
-            const bucket = await storage.ddcCustomers.buckets.v54100.get(
-                block,
-                bucketId,
-            )
+            const bucket = await storage.ddcCustomers.buckets.v54100.get(block, bucketId)
             if (bucket) {
                 bucketInfo = {
                     ownerId: bucket.ownerId,
@@ -110,13 +90,10 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                     bucketId: bucketId,
                     isPublic: bucket.isPublic,
                     isRemoved: bucket.isRemoved,
-                    transferredBytes:
-                        bucket.totalCustomersUsage?.transferredBytes ?? 0n,
+                    transferredBytes: bucket.totalCustomersUsage?.transferredBytes ?? 0n,
                     storedBytes: bucket.totalCustomersUsage?.storedBytes ?? 0n,
-                    numberOfPuts:
-                        bucket.totalCustomersUsage?.numberOfPuts ?? 0n,
-                    numberOfGets:
-                        bucket.totalCustomersUsage?.numberOfGets ?? 0n,
+                    numberOfPuts: bucket.totalCustomersUsage?.numberOfPuts ?? 0n,
+                    numberOfGets: bucket.totalCustomersUsage?.numberOfGets ?? 0n,
                 }
             }
         } else {
@@ -134,20 +111,13 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
         switch (event.name) {
             case events.ddcCustomers.bucketCreated.name: {
                 if (events.ddcCustomers.bucketCreated.v48013.is(event)) {
-                    const bucketId =
-                        events.ddcCustomers.bucketCreated.v48013.decode(event)
+                    const bucketId = events.ddcCustomers.bucketCreated.v48013.decode(event)
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else if (events.ddcCustomers.bucketCreated.v48800.is(event)) {
-                    const bucketId =
-                        events.ddcCustomers.bucketCreated.v48800.decode(
-                            event,
-                        ).bucketId
+                    const bucketId = events.ddcCustomers.bucketCreated.v48800.decode(event).bucketId
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else if (events.ddcCustomers.bucketCreated.v54100.is(event)) {
-                    const bucketId =
-                        events.ddcCustomers.bucketCreated.v54100.decode(
-                            event,
-                        ).bucketId
+                    const bucketId = events.ddcCustomers.bucketCreated.v54100.decode(event).bucketId
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -156,20 +126,13 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
             }
             case events.ddcCustomers.bucketUpdated.name: {
                 if (events.ddcCustomers.bucketUpdated.v48017.is(event)) {
-                    const bucketId =
-                        events.ddcCustomers.bucketUpdated.v48017.decode(event)
+                    const bucketId = events.ddcCustomers.bucketUpdated.v48017.decode(event)
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else if (events.ddcCustomers.bucketUpdated.v48800.is(event)) {
-                    const bucketId =
-                        events.ddcCustomers.bucketUpdated.v48800.decode(
-                            event,
-                        ).bucketId
+                    const bucketId = events.ddcCustomers.bucketUpdated.v48800.decode(event).bucketId
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else if (events.ddcCustomers.bucketUpdated.v54100.is(event)) {
-                    const bucketId =
-                        events.ddcCustomers.bucketUpdated.v54100.decode(
-                            event,
-                        ).bucketId
+                    const bucketId = events.ddcCustomers.bucketUpdated.v54100.decode(event).bucketId
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -178,10 +141,7 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
             }
             case events.ddcCustomers.bucketRemoved.name: {
                 if (events.ddcCustomers.bucketRemoved.v50000.is(event)) {
-                    const bucketId =
-                        events.ddcCustomers.bucketRemoved.v50000.decode(
-                            event,
-                        ).bucketId
+                    const bucketId = events.ddcCustomers.bucketRemoved.v50000.decode(event).bucketId
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -189,15 +149,8 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                 break
             }
             case events.ddcCustomers.bucketTotalNodesUsageUpdated.name: {
-                if (
-                    events.ddcCustomers.bucketTotalNodesUsageUpdated.v54100.is(
-                        event,
-                    )
-                ) {
-                    const bucketId =
-                        events.ddcCustomers.bucketTotalNodesUsageUpdated.v54100.decode(
-                            event,
-                        ).bucketId
+                if (events.ddcCustomers.bucketTotalNodesUsageUpdated.v54100.is(event)) {
+                    const bucketId = events.ddcCustomers.bucketTotalNodesUsageUpdated.v54100.decode(event).bucketId
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -205,15 +158,8 @@ export class DdcBucketsProcessor extends BaseProcessor<State> {
                 break
             }
             case events.ddcCustomers.bucketTotalCustomersUsageUpdated.name: {
-                if (
-                    events.ddcCustomers.bucketTotalCustomersUsageUpdated.v54100.is(
-                        event,
-                    )
-                ) {
-                    const bucketId =
-                        events.ddcCustomers.bucketTotalCustomersUsageUpdated.v54100.decode(
-                            event,
-                        ).bucketId
+                if (events.ddcCustomers.bucketTotalCustomersUsageUpdated.v54100.is(event)) {
+                    const bucketId = events.ddcCustomers.bucketTotalCustomersUsageUpdated.v54100.decode(event).bucketId
                     await this.processDdcBucketsEvents(bucketId, block)
                 } else {
                     throwUnsupportedSpec(event, block)

--- a/src/processors/ddcClustersProcessor.ts
+++ b/src/processors/ddcClustersProcessor.ts
@@ -1,11 +1,6 @@
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import { events, storage } from '../types'
-import {
-    logStorageError,
-    throwUnsupportedSpec,
-    throwUnsupportedStorageSpec,
-    toCereAddress,
-} from '../utils'
+import { logStorageError, throwUnsupportedSpec, throwUnsupportedStorageSpec, toCereAddress } from '../utils'
 import { DdcClusterStatus } from '../model'
 import { BaseProcessor } from './processor'
 
@@ -38,10 +33,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
         super(new Map<string, DdcClusterInfo>())
     }
 
-    private newClusterInfo(
-        clusterId: string,
-        managerId: string,
-    ): DdcClusterInfo {
+    private newClusterInfo(clusterId: string, managerId: string): DdcClusterInfo {
         return {
             id: clusterId,
             managerId: managerId,
@@ -62,73 +54,46 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
         }
     }
 
-    private async processDdcClustersEvents(
-        clusterId: string,
-        block: BlockHeader,
-    ) {
+    private async processDdcClustersEvents(clusterId: string, block: BlockHeader) {
         let clusterInfo: DdcClusterInfo | undefined
         if (storage.ddcClusters.clusters.v48008.is(block)) {
-            const cluster = await storage.ddcClusters.clusters.v48008.get(
-                block,
-                clusterId,
-            )
+            const cluster = await storage.ddcClusters.clusters.v48008.get(block, clusterId)
             if (cluster) {
                 clusterInfo = this.newClusterInfo(clusterId, cluster.managerId)
             }
         } else if (storage.ddcClusters.clusters.v48013.is(block)) {
-            const cluster = await storage.ddcClusters.clusters.v48013.get(
-                block,
-                clusterId,
-            )
+            const cluster = await storage.ddcClusters.clusters.v48013.get(block, clusterId)
             if (cluster) {
                 clusterInfo = this.newClusterInfo(clusterId, cluster.managerId)
             }
         } else if (storage.ddcClusters.clusters.v48016.is(block)) {
-            const cluster = await storage.ddcClusters.clusters.v48016.get(
-                block,
-                clusterId,
-            )
+            const cluster = await storage.ddcClusters.clusters.v48016.get(block, clusterId)
             if (cluster) {
                 clusterInfo = this.newClusterInfo(clusterId, cluster.managerId)
             }
         } else if (storage.ddcClusters.clusters.v53003.is(block)) {
-            const cluster = await storage.ddcClusters.clusters.v53003.get(
-                block,
-                clusterId,
-            )
+            const cluster = await storage.ddcClusters.clusters.v53003.get(block, clusterId)
             if (cluster) {
                 clusterInfo = this.newClusterInfo(clusterId, cluster.managerId)
-                clusterInfo.erasureCodingRequired =
-                    cluster.props.erasureCodingRequired
-                clusterInfo.erasureCodingTotal =
-                    cluster.props.erasureCodingTotal
+                clusterInfo.erasureCodingRequired = cluster.props.erasureCodingRequired
+                clusterInfo.erasureCodingTotal = cluster.props.erasureCodingTotal
                 clusterInfo.replicationTotal = cluster.props.replicationTotal
             }
         } else if (storage.ddcClusters.clusters.v54001.is(block)) {
-            const cluster = await storage.ddcClusters.clusters.v54001.get(
-                block,
-                clusterId,
-            )
+            const cluster = await storage.ddcClusters.clusters.v54001.get(block, clusterId)
             if (cluster) {
                 clusterInfo = this.newClusterInfo(clusterId, cluster.managerId)
-                clusterInfo.erasureCodingRequired =
-                    cluster.props.erasureCodingRequired
-                clusterInfo.erasureCodingTotal =
-                    cluster.props.erasureCodingTotal
+                clusterInfo.erasureCodingRequired = cluster.props.erasureCodingRequired
+                clusterInfo.erasureCodingTotal = cluster.props.erasureCodingTotal
                 clusterInfo.replicationTotal = cluster.props.replicationTotal
                 clusterInfo.status = DdcClusterStatus[cluster.status.__kind]
             }
         } else if (storage.ddcClusters.clusters.v54105.is(block)) {
-            const cluster = await storage.ddcClusters.clusters.v54105.get(
-                block,
-                clusterId,
-            )
+            const cluster = await storage.ddcClusters.clusters.v54105.get(block, clusterId)
             if (cluster) {
                 clusterInfo = this.newClusterInfo(clusterId, cluster.managerId)
-                clusterInfo.erasureCodingRequired =
-                    cluster.props.erasureCodingRequired
-                clusterInfo.erasureCodingTotal =
-                    cluster.props.erasureCodingTotal
+                clusterInfo.erasureCodingRequired = cluster.props.erasureCodingRequired
+                clusterInfo.erasureCodingTotal = cluster.props.erasureCodingTotal
                 clusterInfo.replicationTotal = cluster.props.replicationTotal
                 clusterInfo.status = DdcClusterStatus[cluster.status.__kind]
             }
@@ -139,58 +104,27 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
             clusterInfo.managerId = toCereAddress(clusterInfo.managerId)
             let clusterGovParams
             if (storage.ddcClusters.clustersGovParams.v48013.is(block)) {
-                clusterGovParams =
-                    await storage.ddcClusters.clustersGovParams.v48013.get(
-                        block,
-                        clusterId,
-                    )
+                clusterGovParams = await storage.ddcClusters.clustersGovParams.v48013.get(block, clusterId)
             } else if (storage.ddcClusters.clustersGovParams.v48015.is(block)) {
-                clusterGovParams =
-                    await storage.ddcClusters.clustersGovParams.v48015.get(
-                        block,
-                        clusterId,
-                    )
+                clusterGovParams = await storage.ddcClusters.clustersGovParams.v48015.get(block, clusterId)
             } else if (storage.ddcClusters.clustersGovParams.v48016.is(block)) {
-                clusterGovParams =
-                    await storage.ddcClusters.clustersGovParams.v48016.get(
-                        block,
-                        clusterId,
-                    )
+                clusterGovParams = await storage.ddcClusters.clustersGovParams.v48016.get(block, clusterId)
             } else if (storage.ddcClusters.clustersGovParams.v48017.is(block)) {
-                clusterGovParams =
-                    await storage.ddcClusters.clustersGovParams.v48017.get(
-                        block,
-                        clusterId,
-                    )
+                clusterGovParams = await storage.ddcClusters.clustersGovParams.v48017.get(block, clusterId)
             } else if (storage.ddcClusters.clustersGovParams.v48400.is(block)) {
-                clusterGovParams =
-                    await storage.ddcClusters.clustersGovParams.v48400.get(
-                        block,
-                        clusterId,
-                    )
+                clusterGovParams = await storage.ddcClusters.clustersGovParams.v48400.get(block, clusterId)
             }
             if (clusterGovParams) {
-                clusterInfo.treasuryShare = BigInt(
-                    clusterGovParams.treasuryShare,
-                )
-                clusterInfo.validatorsShare = BigInt(
-                    clusterGovParams.validatorsShare,
-                )
-                clusterInfo.clusterReserveShare = BigInt(
-                    clusterGovParams.clusterReserveShare,
-                )
+                clusterInfo.treasuryShare = BigInt(clusterGovParams.treasuryShare)
+                clusterInfo.validatorsShare = BigInt(clusterGovParams.validatorsShare)
+                clusterInfo.clusterReserveShare = BigInt(clusterGovParams.clusterReserveShare)
                 clusterInfo.storageBondSize = clusterGovParams.storageBondSize
-                clusterInfo.storageChillDelay =
-                    clusterGovParams.storageChillDelay
-                clusterInfo.storageUnbondingDelay =
-                    clusterGovParams.storageUnbondingDelay
+                clusterInfo.storageChillDelay = clusterGovParams.storageChillDelay
+                clusterInfo.storageUnbondingDelay = clusterGovParams.storageUnbondingDelay
                 clusterInfo.unitPerMbStored = clusterGovParams.unitPerMbStored
-                clusterInfo.unitPerMbStreamed =
-                    clusterGovParams.unitPerMbStreamed
-                clusterInfo.unitPerPutRequest =
-                    clusterGovParams.unitPerPutRequest
-                clusterInfo.unitPerGetRequest =
-                    clusterGovParams.unitPerGetRequest
+                clusterInfo.unitPerMbStreamed = clusterGovParams.unitPerMbStreamed
+                clusterInfo.unitPerPutRequest = clusterGovParams.unitPerPutRequest
+                clusterInfo.unitPerGetRequest = clusterGovParams.unitPerGetRequest
             }
             this._state.set(clusterId, clusterInfo)
         } else {
@@ -202,10 +136,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
         switch (event.name) {
             case events.ddcClusters.clusterCreated.name: {
                 if (events.ddcClusters.clusterCreated.v48008.is(event)) {
-                    const clusterId =
-                        events.ddcClusters.clusterCreated.v48008.decode(
-                            event,
-                        ).clusterId
+                    const clusterId = events.ddcClusters.clusterCreated.v48008.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -214,10 +145,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
             }
             case events.ddcClusters.clusterParamsSet.name: {
                 if (events.ddcClusters.clusterParamsSet.v48008.is(event)) {
-                    const clusterId =
-                        events.ddcClusters.clusterParamsSet.v48008.decode(
-                            event,
-                        ).clusterId
+                    const clusterId = events.ddcClusters.clusterParamsSet.v48008.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -226,10 +154,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
             }
             case events.ddcClusters.clusterGovParamsSet.name: {
                 if (events.ddcClusters.clusterGovParamsSet.v48013.is(event)) {
-                    const clusterId =
-                        events.ddcClusters.clusterGovParamsSet.v48013.decode(
-                            event,
-                        ).clusterId
+                    const clusterId = events.ddcClusters.clusterGovParamsSet.v48013.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -237,13 +162,8 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
                 break
             }
             case events.ddcClusters.clusterProtocolParamsSet.name: {
-                if (
-                    events.ddcClusters.clusterProtocolParamsSet.v54001.is(event)
-                ) {
-                    const clusterId =
-                        events.ddcClusters.clusterProtocolParamsSet.v54001.decode(
-                            event,
-                        ).clusterId
+                if (events.ddcClusters.clusterProtocolParamsSet.v54001.is(event)) {
+                    const clusterId = events.ddcClusters.clusterProtocolParamsSet.v54001.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -252,10 +172,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
             }
             case events.ddcClusters.clusterActivated.name: {
                 if (events.ddcClusters.clusterActivated.v54001.is(event)) {
-                    const clusterId =
-                        events.ddcClusters.clusterActivated.v54001.decode(
-                            event,
-                        ).clusterId
+                    const clusterId = events.ddcClusters.clusterActivated.v54001.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -264,10 +181,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
             }
             case events.ddcClusters.clusterBonded.name: {
                 if (events.ddcClusters.clusterBonded.v54001.is(event)) {
-                    const clusterId =
-                        events.ddcClusters.clusterBonded.v54001.decode(
-                            event,
-                        ).clusterId
+                    const clusterId = events.ddcClusters.clusterBonded.v54001.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -276,10 +190,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
             }
             case events.ddcClusters.clusterUnbonded.name: {
                 if (events.ddcClusters.clusterUnbonded.v54001.is(event)) {
-                    const clusterId =
-                        events.ddcClusters.clusterUnbonded.v54001.decode(
-                            event,
-                        ).clusterId
+                    const clusterId = events.ddcClusters.clusterUnbonded.v54001.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -288,10 +199,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
             }
             case events.ddcClusters.clusterNodeValidated.name: {
                 if (events.ddcClusters.clusterNodeValidated.v54001.is(event)) {
-                    const clusterId =
-                        events.ddcClusters.clusterNodeValidated.v54001.decode(
-                            event,
-                        ).clusterId
+                    const clusterId = events.ddcClusters.clusterNodeValidated.v54001.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -300,10 +208,7 @@ export class DdcClustersProcessor extends BaseProcessor<State> {
             }
             case events.ddcClusters.clusterUnbonding.name: {
                 if (events.ddcClusters.clusterUnbonding.v54004.is(event)) {
-                    const clusterId =
-                        events.ddcClusters.clusterUnbonding.v54004.decode(
-                            event,
-                        ).clusterId
+                    const clusterId = events.ddcClusters.clusterUnbonding.v54004.decode(event).clusterId
                     await this.processDdcClustersEvents(clusterId, block)
                 } else {
                     throwUnsupportedSpec(event, block)

--- a/src/processors/ddcNodesProcessor.ts
+++ b/src/processors/ddcNodesProcessor.ts
@@ -1,6 +1,13 @@
+import type { HexString } from '@polkadot/util/types'
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import { events, storage } from '../types'
-import { logStorageError, throwUnsupportedSpec, throwUnsupportedStorageSpec, toCereAddress } from '../utils'
+import {
+    decodeCereAddressFromScaleAddress,
+    logStorageError,
+    throwUnsupportedSpec,
+    throwUnsupportedStorageSpec,
+    toCereAddress,
+} from '../utils'
 import { DdcNodeMode } from '../model'
 import { BaseProcessor } from './processor'
 
@@ -47,7 +54,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v48008.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: nodeId,
+                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: 'localhost',
@@ -67,7 +74,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v48013.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: nodeId,
+                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: node.props.host,
@@ -87,7 +94,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v48017.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: nodeId,
+                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: node.props.host,
@@ -107,7 +114,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v48400.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: nodeId,
+                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: node.props.host,
@@ -127,7 +134,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v54100.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: nodeId,
+                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: node.props.host,
@@ -147,7 +154,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v54113.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: nodeId,
+                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: node.props.host,

--- a/src/processors/ddcNodesProcessor.ts
+++ b/src/processors/ddcNodesProcessor.ts
@@ -2,6 +2,7 @@ import type { HexString } from '@polkadot/util/types'
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import { events, storage } from '../types'
 import {
+    decodeAsciiStringFromScaleVecFixed,
     decodeCereAddressFromScaleAddress,
     logStorageError,
     throwUnsupportedSpec,
@@ -10,6 +11,9 @@ import {
 } from '../utils'
 import { DdcNodeMode } from '../model'
 import { BaseProcessor } from './processor'
+
+const MaxHostLen = 255;
+const MaxDomainLen = 255;
 
 interface DdcNodeInfo {
     id: string
@@ -77,8 +81,8 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                     id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
-                    host: node.props.host,
-                    domain: node.props.domain,
+                    host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
+                    domain: decodeAsciiStringFromScaleVecFixed(MaxDomainLen, node.props.domain as HexString),
                     ssl: node.props.ssl,
                     httpPort: node.props.httpPort,
                     grpcPort: node.props.grpcPort,
@@ -97,8 +101,8 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                     id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
-                    host: node.props.host,
-                    domain: node.props.domain,
+                    host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
+                    domain: decodeAsciiStringFromScaleVecFixed(MaxDomainLen, node.props.domain as HexString),
                     ssl: node.props.ssl,
                     httpPort: node.props.httpPort,
                     grpcPort: node.props.grpcPort,
@@ -117,8 +121,8 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                     id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
-                    host: node.props.host,
-                    domain: node.props.domain,
+                    host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
+                    domain: decodeAsciiStringFromScaleVecFixed(MaxDomainLen, node.props.domain as HexString),
                     ssl: node.props.ssl,
                     httpPort: node.props.httpPort,
                     grpcPort: node.props.grpcPort,
@@ -137,8 +141,8 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                     id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
-                    host: node.props.host,
-                    domain: node.props.domain,
+                    host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
+                    domain: decodeAsciiStringFromScaleVecFixed(MaxDomainLen, node.props.domain as HexString),
                     ssl: node.props.ssl,
                     httpPort: node.props.httpPort,
                     grpcPort: node.props.grpcPort,
@@ -157,8 +161,8 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                     id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
-                    host: node.props.host,
-                    domain: node.props.domain,
+                    host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
+                    domain: decodeAsciiStringFromScaleVecFixed(MaxDomainLen, node.props.domain as HexString),
                     ssl: node.props.ssl,
                     httpPort: node.props.httpPort,
                     grpcPort: node.props.grpcPort,

--- a/src/processors/ddcNodesProcessor.ts
+++ b/src/processors/ddcNodesProcessor.ts
@@ -3,7 +3,6 @@ import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import { events, storage } from '../types'
 import {
     decodeAsciiStringFromScaleVecFixed,
-    decodeCereAddressFromScaleAddress,
     logStorageError,
     throwUnsupportedSpec,
     throwUnsupportedStorageSpec,
@@ -58,7 +57,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v48008.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
+                    id: toCereAddress(node.pubKey),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: 'localhost',
@@ -78,7 +77,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v48013.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
+                    id: toCereAddress(node.pubKey),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
@@ -98,7 +97,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v48017.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
+                    id: toCereAddress(node.pubKey),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
@@ -118,7 +117,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v48400.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
+                    id: toCereAddress(node.pubKey),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
@@ -138,7 +137,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v54100.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
+                    id: toCereAddress(node.pubKey),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),
@@ -158,7 +157,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             const node = await storage.ddcNodes.storageNodes.v54113.get(block, nodeId)
             if (node) {
                 nodeInfo = {
-                    id: decodeCereAddressFromScaleAddress(node.pubKey as HexString),
+                    id: toCereAddress(node.pubKey),
                     providerId: node.providerId,
                     clusterId: node.clusterId,
                     host: decodeAsciiStringFromScaleVecFixed(MaxHostLen, node.props.host as HexString),

--- a/src/processors/ddcNodesProcessor.ts
+++ b/src/processors/ddcNodesProcessor.ts
@@ -1,11 +1,6 @@
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import { events, storage } from '../types'
-import {
-    logStorageError,
-    throwUnsupportedSpec,
-    throwUnsupportedStorageSpec,
-    toCereAddress,
-} from '../utils'
+import { logStorageError, throwUnsupportedSpec, throwUnsupportedStorageSpec, toCereAddress } from '../utils'
 import { DdcNodeMode } from '../model'
 import { BaseProcessor } from './processor'
 
@@ -49,10 +44,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
     private async processDdcNodesEvents(nodeId: string, block: BlockHeader) {
         let nodeInfo: DdcNodeInfo | undefined
         if (storage.ddcNodes.storageNodes.v48008.is(block)) {
-            const node = await storage.ddcNodes.storageNodes.v48008.get(
-                block,
-                nodeId,
-            )
+            const node = await storage.ddcNodes.storageNodes.v48008.get(block, nodeId)
             if (node) {
                 nodeInfo = {
                     id: nodeId,
@@ -72,10 +64,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                 }
             }
         } else if (storage.ddcNodes.storageNodes.v48013.is(block)) {
-            const node = await storage.ddcNodes.storageNodes.v48013.get(
-                block,
-                nodeId,
-            )
+            const node = await storage.ddcNodes.storageNodes.v48013.get(block, nodeId)
             if (node) {
                 nodeInfo = {
                     id: nodeId,
@@ -95,10 +84,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                 }
             }
         } else if (storage.ddcNodes.storageNodes.v48017.is(block)) {
-            const node = await storage.ddcNodes.storageNodes.v48017.get(
-                block,
-                nodeId,
-            )
+            const node = await storage.ddcNodes.storageNodes.v48017.get(block, nodeId)
             if (node) {
                 nodeInfo = {
                     id: nodeId,
@@ -118,10 +104,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                 }
             }
         } else if (storage.ddcNodes.storageNodes.v48400.is(block)) {
-            const node = await storage.ddcNodes.storageNodes.v48400.get(
-                block,
-                nodeId,
-            )
+            const node = await storage.ddcNodes.storageNodes.v48400.get(block, nodeId)
             if (node) {
                 nodeInfo = {
                     id: nodeId,
@@ -141,10 +124,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                 }
             }
         } else if (storage.ddcNodes.storageNodes.v54100.is(block)) {
-            const node = await storage.ddcNodes.storageNodes.v54100.get(
-                block,
-                nodeId,
-            )
+            const node = await storage.ddcNodes.storageNodes.v54100.get(block, nodeId)
             if (node) {
                 nodeInfo = {
                     id: nodeId,
@@ -164,10 +144,7 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
                 }
             }
         } else if (storage.ddcNodes.storageNodes.v54113.is(block)) {
-            const node = await storage.ddcNodes.storageNodes.v54113.get(
-                block,
-                nodeId,
-            )
+            const node = await storage.ddcNodes.storageNodes.v54113.get(block, nodeId)
             if (node) {
                 nodeInfo = {
                     id: nodeId,
@@ -202,69 +179,42 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             case events.ddcClusters.clusterNodeAdded.name: {
                 let decodedEvent
                 if (events.ddcClusters.clusterNodeAdded.v48008.is(event)) {
-                    decodedEvent =
-                        events.ddcClusters.clusterNodeAdded.v48008.decode(event)
-                } else if (
-                    events.ddcClusters.clusterNodeAdded.v48017.is(event)
-                ) {
-                    decodedEvent =
-                        events.ddcClusters.clusterNodeAdded.v48017.decode(event)
+                    decodedEvent = events.ddcClusters.clusterNodeAdded.v48008.decode(event)
+                } else if (events.ddcClusters.clusterNodeAdded.v48017.is(event)) {
+                    decodedEvent = events.ddcClusters.clusterNodeAdded.v48017.decode(event)
                 } else {
                     throwUnsupportedSpec(event, block)
                 }
                 if (decodedEvent) {
-                    const nodesInCluster =
-                        this._state.addedToCluster.get(
-                            decodedEvent.clusterId,
-                        ) ?? new Set<string>()
+                    const nodesInCluster = this._state.addedToCluster.get(decodedEvent.clusterId) ?? new Set<string>()
                     nodesInCluster.add(decodedEvent.nodePubKey.value)
-                    this._state.addedToCluster.set(
-                        decodedEvent.clusterId,
-                        nodesInCluster,
-                    )
+                    this._state.addedToCluster.set(decodedEvent.clusterId, nodesInCluster)
                 }
                 break
             }
             case events.ddcClusters.clusterNodeRemoved.name: {
                 let decodedEvent
                 if (events.ddcClusters.clusterNodeRemoved.v48008.is(event)) {
-                    decodedEvent =
-                        events.ddcClusters.clusterNodeRemoved.v48008.decode(
-                            event,
-                        )
-                } else if (
-                    events.ddcClusters.clusterNodeRemoved.v48017.is(event)
-                ) {
-                    decodedEvent =
-                        events.ddcClusters.clusterNodeRemoved.v48017.decode(
-                            event,
-                        )
+                    decodedEvent = events.ddcClusters.clusterNodeRemoved.v48008.decode(event)
+                } else if (events.ddcClusters.clusterNodeRemoved.v48017.is(event)) {
+                    decodedEvent = events.ddcClusters.clusterNodeRemoved.v48017.decode(event)
                 } else {
                     throwUnsupportedSpec(event, block)
                 }
                 if (decodedEvent) {
                     const nodesRemovedFromCluster =
-                        this._state.removedFromCluster.get(
-                            decodedEvent.clusterId,
-                        ) ?? new Set<string>()
+                        this._state.removedFromCluster.get(decodedEvent.clusterId) ?? new Set<string>()
                     nodesRemovedFromCluster.add(decodedEvent.nodePubKey.value)
-                    this._state.removedFromCluster.set(
-                        decodedEvent.clusterId,
-                        nodesRemovedFromCluster,
-                    )
+                    this._state.removedFromCluster.set(decodedEvent.clusterId, nodesRemovedFromCluster)
                 }
                 break
             }
             case events.ddcNodes.nodeCreated.name: {
                 if (events.ddcNodes.nodeCreated.v48008.is(event)) {
-                    const nodeId =
-                        events.ddcNodes.nodeCreated.v48008.decode(event)
-                            .nodePubKey.value
+                    const nodeId = events.ddcNodes.nodeCreated.v48008.decode(event).nodePubKey.value
                     await this.processDdcNodesEvents(nodeId, block)
                 } else if (events.ddcNodes.nodeCreated.v48017.is(event)) {
-                    const nodeId =
-                        events.ddcNodes.nodeCreated.v48017.decode(event)
-                            .nodePubKey.value
+                    const nodeId = events.ddcNodes.nodeCreated.v48017.decode(event).nodePubKey.value
                     await this.processDdcNodesEvents(nodeId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -273,14 +223,10 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             }
             case events.ddcNodes.nodeParamsChanged.name: {
                 if (events.ddcNodes.nodeParamsChanged.v48008.is(event)) {
-                    const nodeId =
-                        events.ddcNodes.nodeParamsChanged.v48008.decode(event)
-                            .nodePubKey.value
+                    const nodeId = events.ddcNodes.nodeParamsChanged.v48008.decode(event).nodePubKey.value
                     await this.processDdcNodesEvents(nodeId, block)
                 } else if (events.ddcNodes.nodeParamsChanged.v48017.is(event)) {
-                    const nodeId =
-                        events.ddcNodes.nodeParamsChanged.v48017.decode(event)
-                            .nodePubKey.value
+                    const nodeId = events.ddcNodes.nodeParamsChanged.v48017.decode(event).nodePubKey.value
                     await this.processDdcNodesEvents(nodeId, block)
                 } else {
                     throwUnsupportedSpec(event, block)
@@ -290,13 +236,9 @@ export class DdcNodesProcessor extends BaseProcessor<State> {
             case events.ddcNodes.nodeDeleted.name: {
                 let removedNode
                 if (events.ddcNodes.nodeDeleted.v48008.is(event)) {
-                    removedNode =
-                        events.ddcNodes.nodeDeleted.v48008.decode(event)
-                            .nodePubKey.value
+                    removedNode = events.ddcNodes.nodeDeleted.v48008.decode(event).nodePubKey.value
                 } else if (events.ddcNodes.nodeDeleted.v48017.is(event)) {
-                    removedNode =
-                        events.ddcNodes.nodeDeleted.v48017.decode(event)
-                            .nodePubKey.value
+                    removedNode = events.ddcNodes.nodeDeleted.v48017.decode(event).nodePubKey.value
                 } else {
                     throwUnsupportedSpec(event, block)
                 }

--- a/src/processors/processor.ts
+++ b/src/processors/processor.ts
@@ -2,10 +2,7 @@ import { assertNotNull } from '@subsquid/substrate-processor'
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 
 export abstract class BaseProcessor<
-    State extends
-        | Map<any, any>
-        | Set<any>
-        | { [key: string]: Map<any, any> | Set<any> },
+    State extends Map<any, any> | Set<any> | { [key: string]: Map<any, any> | Set<any> },
 > {
     constructor(protected _state: State) {}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { TypeRegistry, GenericAddress } from '@polkadot/types'
+import { TypeRegistry, GenericAddress, VecFixed } from '@polkadot/types'
 import { HexString } from '@polkadot/util/types'
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import * as ss58 from '@subsquid/ss58'
@@ -26,4 +26,13 @@ export const decodeCereAddressFromScaleAddress = (data: HexString) => {
     const decodedGenericAddress = new GenericAddress(registry, data)
     const ss58Address = ss58.decode(decodedGenericAddress.toString())
     return toCereAddress(ss58Address.bytes)
+}
+
+export const decodeAsciiStringFromScaleVecFixed = (vecMaxLen: number, data: HexString) => {
+    // TODO(khssnv): runtime BoundedVec capacity is not available neither from typegen constants nor in the data itself
+    // (as it is available in the beginning of a regular Vec). A runtime upgrade can change the capacity, but right now
+    // we don't know how to deal with it.
+    const decodedVecFixed = new VecFixed(registry, 'u8', vecMaxLen, data)
+    const endOfAsciiValue = decodedVecFixed.toU8a().indexOf(0)
+    return String.fromCharCode(...decodedVecFixed.toU8a().slice(0, endOfAsciiValue))
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { TypeRegistry, GenericAddress, VecFixed } from '@polkadot/types'
+import { TypeRegistry, VecFixed } from '@polkadot/types'
 import { HexString } from '@polkadot/util/types'
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import * as ss58 from '@subsquid/ss58'
@@ -21,12 +21,6 @@ export const toCereAddress = (accoutnId: string) => {
 }
 
 const registry = new TypeRegistry()
-
-export const decodeCereAddressFromScaleAddress = (data: HexString) => {
-    const decodedGenericAddress = new GenericAddress(registry, data)
-    const ss58Address = ss58.decode(decodedGenericAddress.toString())
-    return toCereAddress(ss58Address.bytes)
-}
 
 export const decodeAsciiStringFromScaleVecFixed = (vecMaxLen: number, data: HexString) => {
     // TODO(khssnv): runtime BoundedVec capacity is not available neither from typegen constants nor in the data itself

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,26 +2,16 @@ import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import * as ss58 from '@subsquid/ss58'
 
 export const throwUnsupportedSpec = (event: Event, block: BlockHeader) => {
-    throw Error(
-        `Unsupported spec version for event ${event.name} at block ${block.height} (${block.hash})`,
-    )
+    throw Error(`Unsupported spec version for event ${event.name} at block ${block.height} (${block.hash})`)
 }
 
 export const throwUnsupportedStorageSpec = (block: BlockHeader) => {
-    throw Error(
-        `Unsupported storage spec version at block ${block.height} (${block.hash})`,
-    )
+    throw Error(`Unsupported storage spec version at block ${block.height} (${block.hash})`)
 }
 
-export const logStorageError = (
-    entity: string,
-    key: any,
-    block: BlockHeader,
-) => {
+export const logStorageError = (entity: string, key: any, block: BlockHeader) => {
     // TODO throw Error(`Unable to find ${entity} by key ${key} at block ${block.height} (${block.hash})`)
-    console.log(
-        `Unable to find ${entity} by key ${key} at block ${block.height} (${block.hash})`,
-    )
+    console.log(`Unable to find ${entity} by key ${key} at block ${block.height} (${block.hash})`)
 }
 
 export const toCereAddress = (accoutnId: string) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { TypeRegistry, GenericAddress } from '@polkadot/types'
+import { HexString } from '@polkadot/util/types'
 import { BlockHeader, Event } from '@subsquid/substrate-processor'
 import * as ss58 from '@subsquid/ss58'
 
@@ -16,4 +18,12 @@ export const logStorageError = (entity: string, key: any, block: BlockHeader) =>
 
 export const toCereAddress = (accoutnId: string) => {
     return ss58.codec('cere').encode(accoutnId)
+}
+
+const registry = new TypeRegistry()
+
+export const decodeCereAddressFromScaleAddress = (data: HexString) => {
+    const decodedGenericAddress = new GenericAddress(registry, data)
+    const ss58Address = ss58.decode(decodedGenericAddress.toString())
+    return toCereAddress(ss58Address.bytes)
 }


### PR DESCRIPTION
Storage items getter currently returns hex-strings containing SCALE-encoded values for storage node public key, host, and domain fields. Squid SDK issue reported in https://github.com/subsquid/squid-sdk/issues/335. The patch adds decoding for those values to store ss58 address string as a node public key, and decoded ASCII strings for a node host and domain.

Also code formatter line length parameter increased from 80 to 120.