### PR TITLE
Deploy release tags to stage

### DIFF
--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -1,9 +1,8 @@
 name: Release to stage
 on:
   push:
-    branches:
+    tags:
       - 'release/**'
-      - 'hotfix/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Deploy releases from [Releases](https://github.com/Cerebellum-Network/cere-squid-indexer/releases) page to staging environment.