### PR TITLE
Disable deployment on push

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,8 +1,5 @@
 name: Release to dev
 on:
-  push:
-    branches:
-      - dev
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -1,8 +1,5 @@
 name: Release to prod
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -1,9 +1,5 @@
 name: Release to stage
 on:
-  push:
-    branches:
-      - 'release/**'
-      - 'hotfix/**'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Disable deployment on push (in favor of manual blue / green deployment) to prevent accidental unwanted update of a running processor and its database scheme.